### PR TITLE
Add continue-on-error to tox-pytest ci-notify

### DIFF
--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -48,6 +48,7 @@ jobs:
     steps:
       - name: Inform the Codemonkeys
         uses: 8398a7/action-slack@v3
+        continue-on-error: true
         with:
           status: custom
           fields: workflow,job,commit,repo,ref,author,took

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,13 +10,14 @@ sphinx:
   configuration: docs/conf.py
 
 build:
-  image: testing
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
   apt_packages:
     - libsnappy-dev
 
 # Set the version of Python and requirements required to build your docs
 python:
-  version: "3.10"
   install:
     - method: pip
       path: .


### PR DESCRIPTION
No need to fail the whole run if an external PR doesn't have credentials to post to our Slack.

I thought about adding the GCP/WIF stuff here but I didn't feel like it was universal enough for the template.