### PR TITLE
Add WIF to tox-pytest, and also pass the Google env vars to tox

### DIFF
--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -34,6 +34,15 @@ jobs:
           conda config --show
           printenv | sort
 
+      - name: Set default gcp credentials
+        id: gcloud-auth
+        continue-on-error: true
+        uses: "google-github-actions/auth@v1"
+        with:
+          # you'll need to update the WIF setup in pudl/terraform to allow actions from this repo to access the tox-pytest service account!
+          workload_identity_provider: "projects/345950277072/locations/global/workloadIdentityPools/gh-actions-pool/providers/gh-actions-provider"
+          service_account: "tox-pytest-github-action@catalyst-cooperative-pudl.iam.gserviceaccount.com"
+
       - name: Run PyTest with Tox
         run: |
           conda run -n cheshire tox

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,12 @@ allowlist_externals =
 envdir = {toxinidir}/.env_tox
 passenv =
     CI
+    CLOUDSDK_*
     CONDA_PREFIX
     GITHUB_*
-    GOOGLE_APPLICATION_CREDENTIALS
+    GOOGLE_*
+    GCLOUD_*
+    GCP_*
     HOME
     SQLALCHEMY_WARN_20
 covargs = --cov={envsitepackagesdir}/cheshire --cov-append --cov-report=xml


### PR DESCRIPTION
Pulling in changes from https://github.com/catalyst-cooperative/pudl/pull/2311 - this should make it so people get WIF stuff mostly set up if they use `cheshire`.