### PR TITLE
Remove pep585-upgrade pre-commit hook 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
     rev: v3.8.0
     hooks:
       - id: pyupgrade
-        args: ["--py38-plus"]
+        args: ["--py39-plus"]
 
   # Deterministic python formatting:
   - repo: https://github.com/psf/black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,14 +47,6 @@ repos:
     hooks:
       - id: rm-unneeded-f-str
 
-  # Use built-in types for annotations as per PEP585, with __futures__ for Python 3.8/3.9
-  # Note that this sometimes conflicts with Pydantic on Python 3.8/3.9
-  - repo: https://github.com/sondrelg/pep585-upgrade
-    rev: "v1.0"
-    hooks:
-      - id: upgrade-type-hints
-        args: ["--futures=true"]
-
   # Update a bunch of Python syntax, using __futures__ for Python 3.8/3.9
   # Note that this sometimes conflicts with Pydantic on Python 3.8/3.9
   - repo: https://github.com/asottile/pyupgrade


### PR DESCRIPTION
Remove pep585-upgrade pre-commit hook because pyupgrade now supports native type hints introduced in PEP 858:

From [pep868 repo](https://github.com/snok/pep585-upgrade):
>This package is no longer maintained.
>
>When I wrote this, there were no other alternatives for upgrading type syntax, but pyupgrade has since added support for this. If you are looking for a way to lint your code continuously I would recommend using pyupgrade instead.