### PR TITLE
Swap black out for ruff format. Add GHA Linter. Allow py3.12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Build source and wheel distributions
         run: |
           python -m pip install --upgrade build twine

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 2
 
       - name: Set up conda environment for testing
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v1.9.0
         with:
           environment-file: environment.yml
           cache-environment: true

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
       fail-fast: false
     defaults:
       run:
@@ -27,7 +27,6 @@ jobs:
           condarc: |
             channels:
             - conda-forge
-            - defaults
             channel_priority: strict
 
       - shell: bash -l {0}

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 2
 
       - name: Set up conda environment for testing
-        uses: mamba-org/setup-micromamba@v1.9.0
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: environment.yml
           cache-environment: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+---
 repos:
   # Quick content checks based on grepping for python specific patterns:
   - repo: https://github.com/pre-commit/pygrep-hooks
@@ -15,11 +16,13 @@ repos:
       - id: check-added-large-files # Don't accidentally commit giant files.
       - id: check-merge-conflict # Watch for lingering merge markers.
       - id: check-yaml # Validate all YAML files.
+      - id: check-toml
       - id: check-case-conflict # Avoid case sensitivity in file names.
       - id: debug-statements # Watch for lingering debugger calls.
       - id: mixed-line-ending # Only newlines, no line-feeds.
         args: ["--fix=lf"]
       - id: name-tests-test # Follow PyTest naming convention.
+      - id: end-of-file-fixer
 
   ########################################################################################
   # Formatters: hooks that re-write Python and RST files
@@ -29,13 +32,7 @@ repos:
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
-
-  # Deterministic python formatting:
-  - repo: https://github.com/psf/black
-    rev: 24.8.0
-    hooks:
-      - id: black
-        language_version: python3.11
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8
@@ -70,6 +67,12 @@ repos:
     rev: v2.12.1b3
     hooks:
       - id: hadolint
+
+  # Check Github Actions
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.2
+    hooks:
+      - id: actionlint
 
   ########################################################################################
   # Custom local hooks

--- a/README.rst
+++ b/README.rst
@@ -31,10 +31,6 @@ Cheshire: a Python Template Repository for Catalyst
    :target: https://pypi.org/project/catalystcoop.cheshire/
    :alt: Supported Python Versions
 
-.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
-   :target: https://github.com/psf/black>
-   :alt: Any color you want, so long as it's black.
-
 This template repository helps make new Python projects easier to set up and more
 uniform. It contains a lot of infrastructure surrounding a minimal Python package named
 ``cheshire`` (the cat who isn't entirely there...).
@@ -128,7 +124,7 @@ Python Package Skeleton
 * Python has recently evolved a more diverse community of build and packaging tools.
   Which flavor is being used by a given package is indicated by the contents of
   ``pyproject.toml``. That file also contains configuration for a few other tools,
-  including ``black`` and ``ruff``.
+  including ``ruff``.
 
 Pytest Testing Framework
 ------------------------
@@ -171,7 +167,7 @@ Code Formatting & Linting
 -------------------------
 To avoid the tedium of meticulously formatting all the code ourselves, and to ensure as
 standard style of formatting and sytactical idioms across the codebase, we use the
-``black`` and ``ruff`` code formatters, which run as pre-commit hooks. These can be
+``ruff`` code linter and formatter, which runs as a pre-commit hook. These can be
 integrated directly into your text editor or IDE with the appropriate plugins. The
 formatters are included in ``.pre-commit-config.yaml``. The ``ruff`` linter / formatter
 has a huge array of configuration options and different kinds of checks it can run,

--- a/environment.yml
+++ b/environment.yml
@@ -1,12 +1,12 @@
+---
 name: cheshire
 channels:
   - conda-forge
-  - defaults
 dependencies:
   # Packages required for setting up the environment
-  - pip>=21,<24
-  - python>=3.10,<3.12
-  - setuptools>=66,<69
+  - pip>=21,<25
+  - python>=3.10,<3.13
+  - setuptools>=66
 
   # Packages specified in setup.py that need or benefit from binary conda packages
   # - geopandas>=0.9,<0.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-    "setuptools>=66,<69",
+    "setuptools>=66",
     "setuptools_scm[toml]>=3.5.0",
     "wheel",
 ]
@@ -14,7 +14,7 @@ readme = {file = "README.rst", content-type = "text/x-rst"}
 authors = [
     {name = "Catalyst Cooperative", email = "pudl@catalyst.coop"}
 ]
-requires-python = ">=3.10,<3.12"
+requires-python = ">=3.10,<3.13"
 dynamic = ["version"]
 license = {file = "LICENSE.txt"}
 dependencies = [
@@ -33,6 +33,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 keywords = [
     "template",
@@ -56,7 +57,6 @@ winston = "cheshire.cli:main"
 [project.optional-dependencies]
 dev = [
     "build>=1,<2",  # The setuptools package builder
-    "black>=22,<25",  # A deterministic code formatter
     "tox>=4,<5",  # Python test environment manager
     "twine>=4,<6",  # Used to make releases to PyPI
 ]
@@ -80,7 +80,7 @@ tests = [
     "pytest-console-scripts>=1.1,<2",  # Allow automatic testing of scripts
     "pytest-cov>=4,<6",  # Pytest plugin for working with coverage
     "pytest>=7,<9",  # Our testing framework
-    "ruff>=0.0.290",  # A very fast python linter & autofixer
+    "ruff>=0.6",  # A very fast python linter & autofixer
     "tox>=4,<5",  # Python test environment manager
 ]
 types = [
@@ -95,11 +95,6 @@ include-package-data = true
 
 [tool.setuptools.packages.find]
 where = ["src"]
-
-[tool.black]
-line-length = 88
-target-version = ["py310", "py311"]
-include = "\\.pyi?$"
 
 [tool.doc8]
 max-line-length = 88
@@ -126,40 +121,54 @@ doctest_optionflags = [
 ]
 
 [tool.ruff]
+# Configurations that apply to both the `format` and `lint` subcommands.
+target-version = "py312"
+line-length = 88
+indent-width = 4
+
+[tool.ruff.format]
+# Configuration specfic to the `format` subcommand.
+# We use black compatible formatting.
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+
+[tool.ruff.lint]
 select = [
     "A", # flake8-builtins
-    # "ARG", # unused arguments
-    # "B",  # flake8-bugbear
+    "B",  # flake8-bugbear
     "C",   # Limit cyclomatic complexity using mccabe
+    "C4", # flake8-comprehensions
     "D",   # pydocstyle errors
     "E",   # pycodestyle errors
     "EXE", # executable file issues
-    # "ERA", # eradicate: find commented out code
     "F",   # pyflakes
     "I",   # isort
-    "ISC", # implicit string concatenation
+    "ICN", # flake8 import conventions
     "N",   # pep8-naming
     "NPY", # NumPy specific checks
     "PD",  # pandas checks
     "PGH", # pygrep-hooks
-    # "PL",  # pylint
-    # "PT",  # pytest style
+    "PIE", # flake8-pie miscellaneous linting
     "PTH", # use pathlib
     "Q",   # flake8-quotes
     "RET", # check return values
     "RSE", # unnecessary parenthises on raised exceptions
     "S",   # flake8-bandit
     "SIM", # flake8-simplify
-    # "T",   # print statements found
     "UP", # pyupgrade (use modern python syntax)
     "W",  # pycodestyle warnings
+    # "ARG", # unused arguments
+    # "ERA", # eradicate: find commented out code
+    # "PL",  # pylint
+    # "PT",  # pytest style
+    # "T",   # print statements found
 ]
 ignore = [
     "D401",   # Require imperative mood in docstrings.
     "D417",
     "E501",   # Overlong lines.
-    "PD003",  # Use of isna rather than isnull
-    "PD004",  # Use of notna rather than notnull
     "PD010",  # Use of df.stack()
     "PD013",  # Use of df.unstack()
     "PD015",  # Use of pd.merge() rather than df.merge()
@@ -167,32 +176,26 @@ ignore = [
     "RET504", # Ignore unnecessary assignment before return
     "S101",   # Use of assert
 ]
+extend-select = ["NPY201"] # preview rule to easy migration to Numpy 2.0
 
-# Assume Python 3.11
-target-version = "py311"
-line-length = 88
-
-# Don't automatically concatenate strings -- sometimes we forget a comma!
-unfixable = ["ISC"]
-
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]  # Ignore unused imports
 "tests/*" = ["D"]
 
-[tool.ruff.pep8-naming]
+[tool.ruff.lint.pep8-naming]
 # Allow Pydantic's `@validator` decorator to trigger class method treatment.
 classmethod-decorators = ["pydantic.validator", "pydantic.root_validator"]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["pudl"]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "google"
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 10
 
-[tool.ruff.flake8-quotes]
+[tool.ruff.lint.flake8-quotes]
 docstring-quotes = "double"
 inline-quotes = "double"
 multiline-quotes = "double"
@@ -201,3 +204,24 @@ multiline-quotes = "double"
 python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
+
+[tool.coverage.report]
+precision = 2
+sort = "miss"
+skip_empty = true
+fail_under = 90
+exclude_lines = [
+    # Have to re-enable the standard pragma
+    "pragma: no cover",
+
+    # Don't complain if tests don't hit defensive assertion code:
+    "raise AssertionError",
+    "raise NotImplementedError",
+
+    # Don't complain if non-runnable code isn't run:
+    "if 0:",
+    "if __name__ == .__main__.:",
+
+    # Stuff that's not expected to run normally...
+    "logger.debug",
+]


### PR DESCRIPTION
# Overview

Update the template repo to use tools that we're using in the main PUDL repo now.

# Testing

Ran the CI and it passed.

# To-do list

```[tasklist]
- [x] Switch from using `black` to the `ruff` formatter
- [x] Allow Python 3.12
- [x] Add the GitHub Action workflow linter.
- [x] Update some minimum versions
- [x] Remove use of `default` channel in `environment.yml`
```
